### PR TITLE
Update README.md to match 0.6.0+ versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -329,7 +329,7 @@ The package can be installed by adding [`sage`](https://hex.pm/packages/sage) to
 ```elixir
 def deps do
   [
-    {:sage, "~> 0.4.0"}
+    {:sage, ">= 0.6.0"}
   ]
 end
 ```


### PR DESCRIPTION
Compensations have arity 3 in 0.6.0+ (which is now published in hex), instead of 4 in 0.4.0, which is recommended in the README.md file

Recommended mix dependency should be 
`{:sage, ">= 0.6.0"}`